### PR TITLE
Updated X2ListCriterion list/notList comparison values to be stored a…

### DIFF
--- a/x2engine/protected/migrations/pending/1497047296-list-criteria-to-json.php
+++ b/x2engine/protected/migrations/pending/1497047296-list-criteria-to-json.php
@@ -1,0 +1,68 @@
+<?php
+
+/***********************************************************************************
+ * X2CRM is a customer relationship management program developed by
+ * X2Engine, Inc. Copyright (C) 2011-2016 X2Engine Inc.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY X2ENGINE, X2ENGINE DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ * 
+ * You can contact X2Engine, Inc. P.O. Box 66752, Scotts Valley,
+ * California 95067, USA. on our website at www.x2crm.com, or at our
+ * email address: contact@x2engine.com.
+ * 
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ * 
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * X2Engine" logo. If the display of the logo is not reasonably feasible for
+ * technical reasons, the Appropriate Legal Notices must display the words
+ * "Powered by X2Engine".
+ **********************************************************************************/
+
+/**
+ * Update the existing X2ListCriterion which use the "in list" or "not in list"
+ * comparisons to store the value field as JSON. Previously this was stored as a
+ * comma-separated list of values, which prevents the list from functioning if the
+ * possible values contain commas.
+ */
+$migrateListCriteria = function() {
+    $criteria = Yii::app()->db->createCommand()
+        ->select('id, value')
+        ->from('x2_list_criteria')
+        ->where('comparison = "list"')
+        ->orWhere('comparison = "notList"')
+        ->queryAll();
+    foreach ($criteria as $criterion) {
+        $previousValues = explode(',', $criterion['value']);
+        $newValues = CJSON::encode($previousValues);
+        if (!empty($newValues)) {
+            $test = implode(',', CJSON::decode($newValues));
+            if ($test === $criterion['value']) {
+                Yii::app()->db->createCommand()
+                    ->update('x2_list_criteria', array(
+                        'value' => $newValues,
+                    ), 'id = :id', array(
+                        ':id' => $criterion['id'],
+                    ));
+            }
+        }
+    }
+};
+$migrateListCriteria();

--- a/x2engine/protected/modules/contacts/models/X2List.php
+++ b/x2engine/protected/modules/contacts/models/X2List.php
@@ -358,10 +358,10 @@ class X2List extends X2Model {
                             $search->addCondition('('.'t.'.$criterion->attribute.'="" OR '.'t.'.$criterion->attribute.' IS NULL)', $logicMode);
                             break;
                         case 'list':
-                            $search->addInCondition('t.'.$criterion->attribute, explode(',', $criterion->value), $logicMode);
+                            $search->addInCondition('t.'.$criterion->attribute, CJSON::decode($criterion->value), $logicMode);
                             break;
                         case 'notList':
-                            $search->addNotInCondition('t.'.$criterion->attribute, explode(',', $criterion->value), $logicMode);
+                            $search->addNotInCondition('t.'.$criterion->attribute, CJSON::decode($criterion->value), $logicMode);
                             break;
                         case 'noContains':
                             $search->compare('t.'.$criterion->attribute, '<>'.$criterion->value, true, $logicMode);

--- a/x2engine/protected/modules/contacts/views/contacts/_listForm.php
+++ b/x2engine/protected/modules/contacts/views/contacts/_listForm.php
@@ -320,8 +320,8 @@ function createValueCell(field) {
         case 'dropdown':
         case 'assignment':
         case 'optionalAssignment':
-            //we maintain a hidden field along with the multiselect to hold a comma
-            //separated list of the multiselect values, in order to post them as one field
+            //we maintain a hidden field along with the multiselect to hold a JSON
+            //encoded list of the multiselect values, in order to post them as one field
             hidden = $('<input type="hidden">');
             hidden.attr('name', 'X2List[value][]');
             input = createDropdown(fieldOptions[field]);
@@ -329,11 +329,15 @@ function createValueCell(field) {
             input.attr('multiple', 'multiple');
             input.on('change', function(e) {
                 //user change - update hidden field
-                hidden.val(input.val());
+                hidden.val(JSON.stringify(input.val()));
             });
             hidden.on('change', function(e) {
                 //programatic change - update the multiselect
-                input.val($(this).val().split(','));
+                var value = $(this).val();
+                if (value) {
+                    var decoded = JSON.parse(value);
+                    input.val(decoded);
+                }
             });
             break;
         case 'varchar':

--- a/x2engine/protected/tests/fixtures/x2_list_criteria.MigrateCriteriaToJson.php
+++ b/x2engine/protected/tests/fixtures/x2_list_criteria.MigrateCriteriaToJson.php
@@ -1,0 +1,36 @@
+<?php
+return array(
+    'excluded' => array(
+        'id' => '38',
+        'listId' => '22',
+        'type' => 'attribute',
+        'attribute' => 'email',
+        'comparison' => 'contains',
+        'value' => 'mailinator.com',
+    ),
+    'testMultiple' => array(
+        'id' => '39',
+        'listId' => '22',
+        'type' => 'attribute',
+        'attribute' => 'c_dropdown',
+        'comparison' => 'list',
+        'value' => 'First Option,SecondOption',
+    ),
+    'testSingle' => array(
+        'id' => '40',
+        'listId' => '22',
+        'type' => 'attribute',
+        'attribute' => 'c_dropdown',
+        'comparison' => 'notList',
+        'value' => 'SecondOption',
+    ),
+    'testNone' => array(
+        'id' => '41',
+        'listId' => '22',
+        'type' => 'attribute',
+        'attribute' => 'c_dropdown',
+        'comparison' => 'list',
+        'value' => '',
+    ),
+);
+?>

--- a/x2engine/protected/tests/unit/migrations/7.0/ListCriteriaToJsonTest.php
+++ b/x2engine/protected/tests/unit/migrations/7.0/ListCriteriaToJsonTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/***********************************************************************************
+ * X2CRM is a customer relationship management program developed by
+ * X2Engine, Inc. Copyright (C) 2011-2016 X2Engine Inc.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY X2ENGINE, X2ENGINE DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ * 
+ * You can contact X2Engine, Inc. P.O. Box 66752, Scotts Valley,
+ * California 95067, USA. on our website at www.x2crm.com, or at our
+ * email address: contact@x2engine.com.
+ * 
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ * 
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * X2Engine" logo. If the display of the logo is not reasonably feasible for
+ * technical reasons, the Appropriate Legal Notices must display the words
+ * "Powered by X2Engine".
+ **********************************************************************************/
+
+/**
+ * Tests the 7.0 migration to update existing X2ListCriterion to store the "value"
+ * of "list" and "notList" comparisons as JSON instead of a comma-separated list.
+ */
+class ListCriteriaToJsonMigrationTest extends X2DbTestCase {
+    public $fixtures = array (
+        'criteria' => array ('X2ListCriterion', '.MigrateCriteriaToJson'),
+    );
+
+    public function testMigrationScript() {
+        $multiple = $this->criteria('testMultiple');
+        $single = $this->criteria('testSingle');
+        $none = $this->criteria('testNone');
+        $excluded = $this->criteria('excluded');
+        $this->runMigrationScript();
+        $this->assertValueReencoded($multiple);
+        $this->assertValueReencoded($single);
+        $this->assertValueReencoded($none);
+        $this->assertValueIntact($excluded);
+    }
+
+    /**
+     * Asserts that the model's new JSON-encoded field can be properly unpacked and
+     * reconstructed as the previous comma-separated value
+     * @param X2ListCriterion $model List criteria model before migrating (comma-separated)
+     */
+    public function assertValueReencoded($model) {
+        $modified = X2ListCriterion::model()->findByPk($model->id);
+        $this->assertTrue($modified instanceof X2ListCriterion);
+        $this->assertTrue(AuxLib::isJson($modified->value));
+        $this->assertEquals($model->value, implode(',', CJSON::decode($modified->value)));
+    }
+
+    /**
+     * Asserts that a model's value field was left intact
+     */
+    public function assertValueIntact($model) {
+        $modified = X2ListCriterion::model()->findByPk($model->id);
+        $this->assertTrue($modified instanceof X2ListCriterion);
+        $this->assertEquals($model->value, $modified->value);
+    }
+
+    public function runMigrationScript() {
+        $command = Yii::app()->basePath . '/yiic runmigrationscript ' .
+                'migrations/pending/1497047296-list-criteria-to-json.php';
+        $return_var;
+        $output = array();
+        if (X2_TEST_DEBUG_LEVEL > 1) {
+            print_r(exec($command, $return_var, $output));
+        } else {
+            exec($command, $return_var, $output);
+        }
+        X2_TEST_DEBUG_LEVEL > 1 && print_r($return_var);
+        X2_TEST_DEBUG_LEVEL > 1 && print_r($output);
+    }
+}


### PR DESCRIPTION
…s JSON

Due to incompatibilities with storing dropdown values with commas, the X2ListCriterion.value field has been updated to store the chosen values as JSON data. To account for existing installations, a migration script has been added which will handle updating existing list criteria to use JSON instead of a comma-separated list.